### PR TITLE
Dateで月情報を管理する

### DIFF
--- a/lib/month_constrain.rb
+++ b/lib/month_constrain.rb
@@ -1,5 +1,5 @@
+require 'active_record' unless defined? ActiveRecord
 require "month_constrain/version"
+require 'month_constrain/active_record_base'
 
-module MonthConstrain
-  # Your code goes here...
-end
+ActiveRecord::Base.send :extend, MonthConstrain::ActiveRecordBase

--- a/lib/month_constrain/active_record_base.rb
+++ b/lib/month_constrain/active_record_base.rb
@@ -1,0 +1,21 @@
+require 'month_constrain/active_record_base/initializer'
+
+module MonthConstrain
+  module ActiveRecordBase
+    def acts_as_month_constrain(*columns)
+      Initializer.setter(self, columns)
+      Initializer.scope(self, columns)
+    end
+
+    def month_constrain(value)
+      case value
+        when Date, Time, ActiveSupport::TimeWithZone
+          Date.new(value.year, value.month, 1)
+        when /\A(\d{4})-(\d{1,2})/
+          Date.new(Regexp.last_match(1).to_i, Regexp.last_match(2).to_i, 1)
+      end
+    rescue ArgumentError => ex
+      nil
+    end
+  end
+end

--- a/lib/month_constrain/active_record_base/initializer.rb
+++ b/lib/month_constrain/active_record_base/initializer.rb
@@ -1,0 +1,31 @@
+module MonthConstrain::ActiveRecordBase
+  module Initializer
+    def self.setter(target_class, columns)
+      target_class.class_eval do
+        columns.each do |column|
+          define_method "#{column}=" do |val|
+            super(self.class.month_constrain(val))
+          end
+        end
+      end
+    end
+
+    def self.scope(target_class, columns)
+      target_class.class_eval do
+        columns.each do |column|
+          scope "#{column}_in".to_sym, -> (from, to) do
+            relation = self
+            relation = relation.where("#{column} >= ?", month_constrain(from)) if from
+            relation = relation.where("#{column} <= ?", month_constrain(to)) if to
+            relation
+          end
+
+          scope "#{column}".to_sym, -> (val) do
+            where(column => month_constrain(val))
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/month_constrain.gemspec
+++ b/month_constrain.gemspec
@@ -19,7 +19,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'activesupport', '>= 4.2.3'
+  spec.add_dependency 'activerecord', '>= 4.0'
+
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "sqlite3", "~> 1.0"
 end

--- a/spec/month_constrain_spec.rb
+++ b/spec/month_constrain_spec.rb
@@ -1,11 +1,77 @@
 require 'spec_helper'
 
+class User < ActiveRecord::Base
+  acts_as_month_constrain :registration_month
+end
+
 describe MonthConstrain do
-  it 'has a version number' do
-    expect(MonthConstrain::VERSION).not_to be nil
+  let(:column) { 'registration_month' }
+  let(:base_date) { Date.parse('2016-01-01') }
+  let(:delta) { 10 }
+  before { User.destroy_all }
+  subject { User.create(registration_month: base_date) }
+
+  describe '.month_constrain' do
+    [
+      '2016-01',
+      '2016-1',
+      '2016-01-1',
+      '2016-1-01',
+      '2016-01-01',
+      '2016-01-12',
+      Time.zone.parse('2016-01-12'),
+      Date.parse('2016-01-12'),
+      Time.parse('2016-01-12'),
+    ].each do |val|
+      context "when specifies #{val} (#{val.class})" do
+        before { subject.__send__("#{column}=", val) }
+        it 'returns 1st' do
+          expect(subject.__send__(column).day).to eq(1)
+        end
+      end
+    end
+
+    %w(
+      aaaaaaaaaaaa
+      222222222222
+      2012-33-33
+    ).each do |val|
+      context "when specifies #{val}" do
+        before { subject.__send__("#{column}=", val) }
+        it 'returns nil' do
+          expect(subject.__send__(column)).to eq(nil)
+        end
+      end
+    end
   end
 
-  it 'does something useful' do
-    expect(false).to eq(true)
+  describe 'scope' do
+    it "should return records [column]_in in the period", :aggregate_failures do
+      [
+        ['2016-01'        , nil              , [subject]],
+        ['2016-02'        , nil              , []],
+        ['2015-12'        , nil              , [subject]],
+        [nil              , '2016-01'        , [subject]],
+        [nil              , '2016-02'        , [subject]],
+        [nil              , '2015-12'        , []],
+        ['2016-01'        , '2016-01'        , [subject]],
+        ['2015-12'        , '2016-02'        , [subject]],
+        ['2016-02'        , '2015-12'        , []],
+      ].each do |from, to, expected|
+        result = User.__send__("#{column}_in", [from, to])
+        expect(result).to contain_exactly(*expected)
+      end
+    end
+
+    it "should return records [column]", :aggregate_failures do
+      [
+        ['2016-01'        , [subject]],
+        ['2016-12'        , []],
+        [nil              , []],
+      ].each do |target_date, expected|
+        result = User.__send__("#{column}", target_date)
+        expect(result).to contain_exactly(*expected)
+      end
+    end
   end
 end

--- a/spec/month_constrain_spec.rb
+++ b/spec/month_constrain_spec.rb
@@ -11,6 +11,10 @@ describe MonthConstrain do
   before { User.destroy_all }
   subject { User.create(registration_month: base_date) }
 
+  it 'has a version number' do
+    expect(MonthConstrain::VERSION).not_to be nil
+  end
+
   describe '.month_constrain' do
     [
       '2016-01',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'month_constrain'
+require 'bundler/setup'
+Bundler.require
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }

--- a/spec/support/create_database.rb
+++ b/spec/support/create_database.rb
@@ -1,0 +1,13 @@
+ActiveRecord::Base.configurations = { 'test' => {adapter: 'sqlite3', database: ':memory:' } }
+ActiveRecord::Base.establish_connection :test
+
+class CreateUsers < ActiveRecord::Migration
+  def self.up
+    create_table(:users) do |t|
+      t.date :registration_month
+    end
+  end
+end
+
+ActiveRecord::Migration.verbose = false
+CreateUsers.up

--- a/spec/support/timezone.rb
+++ b/spec/support/timezone.rb
@@ -1,0 +1,2 @@
+require 'active_support'
+Time.zone = 'Tokyo'


### PR DESCRIPTION
## 目的

指定したカラムを月情報を管理するカラムとして扱うことが出来る。
データベース上ではDate型で保存して1日で保存する。
## TODO
- [x] ユーザーの入力を1日のDate側へ変換する。
  - `Date`, `Time`, `ActiveSupport::TimeWithZone`, `2016-12形式の文字列`
- [x] モデルで `acts_as_month_constrain` と定義することで月情報管理が出来るように実装
- [x] 月情報として扱っているカラムのscope
  - 範囲指定できる `[column name]_in('2016-1', '2016-2')` と直接指定できる `[column_name]('2016-01')`
- [x] rspecによるテスト
- [x] 💣 LICECEやREADEMEなどはプログラムが完成した際に作成するので今回はプログラムのみ
- [x] 💣 CIの設定も今回は行わい
## 使用イメージ

```
class User < ApplicationRecord
   acts_as_month_constrain :registration_month
   ~~
end
```

```
[1] pry(main)> User.registration_month_in('2015-09', '2016-09')
  User Load (0.8ms)  SELECT `users`.* FROM `users` WHERE (registration_month >= '2015-09-01') AND (billing_month <= '2016-09-01')

[2] pry(main)> User.registration_month('2016-09')
  User Load (0.3ms)  SELECT `users`.* FROM `users` WHERE `users`.`registration_month` = '2016-09-01'
```
