### PR TITLE
TravisCIのチューニング

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 sudo: false
 language: ruby
+
 rvm:
   - 2.3.1
+  - 2.2.5
+
+env:
+  - RAILS_VERSION=5.0.0.1
+  - RAILS_VERSION=4.2.7.1
+
 before_install: gem install bundler -v 1.12.5

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in month_constrain.gemspec
 gemspec
+
+group :test do
+  gem 'activesupport', ENV['RAILS_VERSION'] || '5.0.0.1'
+  gem 'activerecord',  ENV['RAILS_VERSION'] || '5.0.0.1'
+end

--- a/spec/month_constrain_spec.rb
+++ b/spec/month_constrain_spec.rb
@@ -62,7 +62,7 @@ describe MonthConstrain do
         ['2015-12'        , '2016-02'        , [subject]],
         ['2016-02'        , '2015-12'        , []],
       ].each do |from, to, expected|
-        result = User.__send__("#{column}_in", [from, to])
+        result = User.__send__("#{column}_in", from, to)
         expect(result).to contain_exactly(*expected)
       end
     end


### PR DESCRIPTION
## 目的

いくつかのRubyバージョン、RailsバージョンでTravisCIを走らせる
## 方針
- TravisCIはrvmに列挙したRubyバージョン×envに列挙した環境変数群の全組み合わせでテストするのでこれを利用
- 環境変数に指定されたRailsのバージョンをテストに使うように`Gemfile`に記載
  - `gemspec`ではなく`Gemfile`に記載するので、gemユーザには影響しない
## 見て欲しい所

Rails4.2.7.1だとテストが通らなかったので直した
scopeに配列を渡したときに展開してくれないっぽい
