### PR TITLE
Arel対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'activesupport', ENV['RAILS_VERSION'] || '5.0.0.1'
   gem 'activerecord',  ENV['RAILS_VERSION'] || '5.0.0.1'
+  gem 'activesupport', ENV['RAILS_VERSION'] || '5.0.0.1'
 end

--- a/lib/month_constrain/active_record_base/initializer.rb
+++ b/lib/month_constrain/active_record_base/initializer.rb
@@ -15,8 +15,8 @@ module MonthConstrain::ActiveRecordBase
         columns.each do |column|
           scope "#{column}_in".to_sym, lambda { |from, to|
             relation = self
-            relation = relation.where("#{column} >= ?", month_constrain(from)) if from
-            relation = relation.where("#{column} <= ?", month_constrain(to)) if to
+            relation = relation.where(self.arel_table[column.to_sym].gteq(month_constrain(from))) if from
+            relation = relation.where(self.arel_table[column.to_sym].lteq(month_constrain(to))) if to
             relation
           }
 

--- a/spec/month_constrain_spec.rb
+++ b/spec/month_constrain_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 
 class User < ActiveRecord::Base
+  has_many :books
+  acts_as_month_constrain :registration_month
+end
+
+class Book < ActiveRecord::Base
+  belongs_to :user
   acts_as_month_constrain :registration_month
 end
 
@@ -75,6 +81,14 @@ describe MonthConstrain do
       ].each do |target_date, expected|
         result = User.__send__(column.to_s, target_date)
         expect(result).to contain_exactly(*expected)
+      end
+    end
+
+    context 'when duplicate column' do
+      before { Book.create(registration_month: base_date, user: subject) }
+      let(:users) { User.joins(:books).__send__("#{column}_in", base_date, base_date) }
+      it 'returns user records' do
+        expect(users).to be_present
       end
     end
   end

--- a/spec/support/create_database.rb
+++ b/spec/support/create_database.rb
@@ -6,6 +6,11 @@ class CreateUsers < ActiveRecord::Migration
     create_table(:users) do |t|
       t.date :registration_month
     end
+
+    create_table(:books) do |t|
+      t.date :registration_month
+      t.references :user, foreign_key: true
+    end
   end
 end
 


### PR DESCRIPTION
## 目的
全く同じカラムが存在するモデルに対して `acts_as_month_constrain` で適用し
joinをすると `Ambiguous column` が発生してしまうのでArelを使って回避する

## TODO
- [x] Arelを使用してacts_as_month_constrainを適用しているモデルのカラムを明示する
- [x] テストの記載